### PR TITLE
Fix keyboard field of redox-seniply.json

### DIFF
--- a/downloads/qmk/redox/rev1/redox-seniply.json
+++ b/downloads/qmk/redox/rev1/redox-seniply.json
@@ -2,7 +2,7 @@
   "version": 1,
   "notes": "",
   "documentation": "\"This file is a QMK Configurator export. You can import this at <https://config.qmk.fm>. It can also be used directly with QMK's source code.\n\nTo setup your QMK environment check out the tutorial: <https://docs.qmk.fm/#/newbs>\n\nYou can convert this file to a keymap.c using this command: `qmk json2c {keymap}`\n\nYou can compile this keymap using this command: `qmk compile {keymap}`\"\n",
-  "keyboard": "redox/rev1",
+  "keyboard": "redox/rev1/base",
   "keymap": "redox-seniply",
   "layout": "LAYOUT",
   "layers": [


### PR DESCRIPTION
`redox/rev1` is not a valid keyboard value. Possible valid values are `redox/rev1/base` or `redox/rev1/proton_c`